### PR TITLE
Added inline keyword to non-template functions

### DIFF
--- a/src/json.hpp
+++ b/src/json.hpp
@@ -14,13 +14,13 @@
 
 namespace json {
 
-JSON read(std::istream &in, bool skipOverErrors = false) {
+inline JSON read(std::istream &in, bool skipOverErrors = false) {
   using Iterator = std::istream_iterator<char>;
   Parser<Iterator> parser(Iterator(in), Iterator(), skipOverErrors);
   return read(parser);
 }
 
-JSON read(const std::string &in, bool skipOverErrors = false) {
+inline JSON read(const std::string &in, bool skipOverErrors = false) {
   Parser<std::string::const_iterator> parser(in.cbegin(), in.cend(), skipOverErrors);
   return read(parser);
 }
@@ -31,7 +31,7 @@ JSON read(T begin, T end, bool skipOverErrors = false) {
   return read(parser);
 }
 
-istream& operator >>(istream& i, json::JSON& j) {
+inline istream& operator >>(istream& i, json::JSON& j) {
   j = read(i);
   return i;
 }
@@ -42,7 +42,7 @@ using LocStreamIterator = LocatingIterator<StreamIterator>;
 #else
 using LocStreamIterator = StreamIterator;
 #endif
-std::pair<JSON, LocStreamIterator> readWithPos(std::istream &in, bool skipOverErrors = false) {
+inline std::pair<JSON, LocStreamIterator> readWithPos(std::istream &in, bool skipOverErrors = false) {
   Parser<StreamIterator> parser(StreamIterator(in), StreamIterator(), skipOverErrors);
   JSON&& result(read(parser));
   auto p = parser.json();
@@ -54,7 +54,7 @@ using LocStringIterator = LocatingIterator<std::string::const_iterator>;
 #else
 using LocStringIterator = std::string::const_iterator;
 #endif
-std::pair<JSON, LocStringIterator> readWithPos(const std::string &in, bool skipOverErrors = false) {
+inline std::pair<JSON, LocStringIterator> readWithPos(const std::string &in, bool skipOverErrors = false) {
   Parser<std::string::const_iterator> parser(in.cbegin(), in.cend(), skipOverErrors);
   JSON&& result(read(parser));
   auto p = parser.json();

--- a/src/json_class.hpp
+++ b/src/json_class.hpp
@@ -21,7 +21,7 @@ struct JSON {
 public:
     enum Type {null, boolean, number, text, map, list};
 private:
-    friend std::ostream& operator <<(ostream& s, const JSON& j);
+    inline friend std::ostream& operator <<(ostream& s, const JSON& j);
     Type type;
     union Value {
         std::string as_string;
@@ -209,7 +209,7 @@ public:
     }
 };
 
-std::ostream &operator<<(ostream &s, const JMap &j) {
+inline std::ostream &operator<<(ostream &s, const JMap &j) {
   s << '{';
   auto entry = j.cbegin();
   auto end = j.cend();
@@ -226,7 +226,7 @@ std::ostream &operator<<(ostream &s, const JMap &j) {
   return s;
 }
 
-std::ostream &operator<<(ostream &s, const JList &j) {
+inline std::ostream &operator<<(ostream &s, const JList &j) {
   s << '[';
   auto entry = j.cbegin();
   auto end = j.cend();
@@ -242,7 +242,7 @@ std::ostream &operator<<(ostream &s, const JList &j) {
   return s;
 }
 
-std::ostream& operator <<(ostream& s, const JSON& j) {
+inline std::ostream& operator <<(ostream& s, const JSON& j) {
     switch(j.type) {
         case JSON::null: s << "null"; break;
         case JSON::boolean: s << (j.value.as_bool ? "true" : "false"); break;
@@ -260,7 +260,7 @@ std::ostream& operator <<(ostream& s, const JSON& j) {
     return s;
 }
 
-JSON JBool(bool val) {
+inline JSON JBool(bool val) {
     return JSON(val, 1);
 }
 

--- a/src/utf82json.hpp
+++ b/src/utf82json.hpp
@@ -165,7 +165,7 @@ void utf82wchar(Iterator in, Iterator end, OutIterator out) {
 
 /** Converts a UTF8 enconded string into a json string
  */
-std::string utf82json(const std::string& utf8) {
+inline std::string utf82json(const std::string& utf8) {
   std::string result;
   result.reserve(utf8.size() * 1.1);  // Assume a 10% size increase
   utf82json(utf8.cbegin(), utf8.cend(), back_inserter(result));
@@ -174,6 +174,6 @@ std::string utf82json(const std::string& utf8) {
 
 /** Converts a UTF8 enconded string into a json string
  */
-void utf82json(const std::string& utf8, std::string& out) {
+inline void utf82json(const std::string& utf8, std::string& out) {
   utf82json(utf8.cbegin(), utf8.cend(), back_inserter(out));
 }


### PR DESCRIPTION
When I include json.hpp in one of my header files and then reference that header file from other header files I start getting "multiple definition of" errors. I believe only template functions should be defined within header files yet you have some non-template functions defined as well. One way around this is to just add the inline keyword to the function definitions which is what I did here.

Cheers!
